### PR TITLE
Removing argparse Package Dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ pygrib
 netCDF4
 pyyaml
 scipy
-argparse
 pandas
 matplotlib
 pytest

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,6 @@ setup(
     url="https://github.com/NOAA-GSL/VCasT",
     install_requires=[
         "pyyaml<=6.0.1",
-        "argparse",  # standard lib in Python 3.2+, included for legacy consistency
         "colorama<=0.4.6",
     ],
     extras_require=extras_require,


### PR DESCRIPTION
# Issue
Following the `all` [install instruction](https://vcast.readthedocs.io/en/latest/pages/overview/quick-start.html#install-vcast) on Derecho fails. It tries to install the `argparse` package and will attempt to install older versions of the other packages.

# Fix
Removing argparse as an install requirement, since it is already included as part of the Python standard library. Since [Python versions before 3.9](https://devguide.python.org/versions/) are not getting security updates, there is no need to support them.

